### PR TITLE
Ajout d’une option “fieldInsert” dans la config

### DIFF
--- a/_widgets/autocomplete/autocomplete.ts
+++ b/_widgets/autocomplete/autocomplete.ts
@@ -123,7 +123,7 @@ export class AutocompleteComponent {
         this.toggleDropdown();
         this.inputValue = "";
         this.setCursorPosition(0);
-        this.placeholder = item[this.config.fieldSearch];//item[this.config.fieldName];
+        this.placeholder = this.config.fieldInsert ? item[this.config.fieldInsert] : item[this.config.fieldSearch];
     }
 
     //GESTION DU CLIC EN DEHORS DU CHAMP


### PR DESCRIPTION
Option pour choisir le champ à insérer comme valeur visible de l'autocomplete lorsqu'on clique sur un résultat