### PR TITLE
Ajout d'un paramètre dans la configuration + màj doc

### DIFF
--- a/_widgets/autocomplete/autocomplete.ts
+++ b/_widgets/autocomplete/autocomplete.ts
@@ -47,6 +47,10 @@ export class AutocompleteComponent {
 
         this.reduceResultList();
         this.items.subscribe();
+
+        if(typeof this.config.modifyPlaceholder === "undefined") {
+            this.config.modifyPlaceholder = true;
+        }
     }
 
     ngOnChanges(changes) {
@@ -128,6 +132,9 @@ export class AutocompleteComponent {
         this.inputValue = "";
         this.setCursorPosition(0);
         this.placeholder = this.config.fieldInsert ? item[this.config.fieldInsert] : item[this.config.fieldDisplayed];
+        if(this.config.modifyPlaceholder) {
+            this.placeholder = this.config.fieldInsert ? item[this.config.fieldInsert] : item[this.config.fieldDisplayed];
+        }
     }
 
     // GESTION DU CLIC EN DEHORS DU CHAMP

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -19,6 +19,7 @@ Le composant d'autocomplete doit être appelé de la façon suivante:
     * **begin**: *Number* - nombre de caractères à entrer dans le champ avant que l'autocomplete ne se lance
     * **defaultValue**: *String* - valeur par défaut à insérer dans l'input d'autocompletion
     * **placeholder**: *String* - Placeholder du champ
+    * **modifyPlaceholder**: *Boolean* - Si true, alors le placeholder prends la valeur du champs sélectionné. Vaut true par défaut.
 * **(valid)**: *Function* - fonction appelée lorsque le champ est validé sur un resultat existant
 * **(create)**: *Function* - fonction appelée lorsqu'on fait "ENTREE" sur un texte inexistant
 


### PR DESCRIPTION
On peut choisir ou non si on veut modifier le nom de l'autocomplete après validation du champs.