### PR TITLE
Modification trim autocomplete

### DIFF
--- a/_widgets/autocomplete/autocomplete.ts
+++ b/_widgets/autocomplete/autocomplete.ts
@@ -74,12 +74,17 @@ export class AutocompleteComponent implements OnInit, OnChanges {
   // reduit le nombre de resultat, en fonction de la valeur tapé
   reduceResultList() {
     this.results = [];
-    if (this.inputValue && this.inputValue.length >= this.config.begin) {
+    // Variable intermédiaire de recherche pour éviter de trimer la valeur dans le champ
+    let searchValue = '';
+    if (this.inputValue) {
+      searchValue = this.inputValue.trim();
+    }
+    if (searchValue && searchValue.length >= this.config.begin) {
           // filtre simple
           // this.results = this.data.filter(item => item.complete_label.toLowerCase().includes(this.inputValue.toLowerCase()));
 
       if (this.config.customSearch) {
-        this.config.customSearch.apply(this.config.scope, [this.inputValue]).subscribe(res => {
+        this.config.customSearch.apply(this.config.scope, [searchValue]).subscribe(res => {
           this.results = res;
           this.addRemoveData();
         });
@@ -89,7 +94,7 @@ export class AutocompleteComponent implements OnInit, OnChanges {
           let sub = new Observable(observer => {
             let res = slice.filter(item => {
                 let searchable_text = this.config.fieldSearch ? item[this.config.fieldSearch] : item[this.config.fieldDisplayed];
-              return this.slugify(searchable_text).includes(this.slugify(this.inputValue));
+              return this.slugify(searchable_text).includes(this.slugify(searchValue));
             });
             observer.next(res);
             observer.complete();

--- a/_widgets/autocomplete/autocomplete.ts
+++ b/_widgets/autocomplete/autocomplete.ts
@@ -74,9 +74,6 @@ export class AutocompleteComponent implements OnInit, OnChanges {
   // reduit le nombre de resultat, en fonction de la valeur tapé
   reduceResultList() {
     this.results = [];
-    if (this.inputValue) {
-      this.inputValue = this.inputValue.trim();
-    }
     if (this.inputValue && this.inputValue.length >= this.config.begin) {
           // filtre simple
           // this.results = this.data.filter(item => item.complete_label.toLowerCase().includes(this.inputValue.toLowerCase()));


### PR DESCRIPTION
Suite à une demande client, j'ai besoin de supprimer le trim de la recherche. Celui-ci empêche de rechercher correctement un résultat qui contient un espace dedans.
Exemple pour rechercher "Paul Thomas", si l'on tape "Paul ", la recherche (dont le trim) se lance bien avant qu'on ai le temps d'écrire le premier T.
